### PR TITLE
remove memory allocation inside main loop

### DIFF
--- a/OpenMXPlayer/src/net/pocketmagic/android/openmxplayer/OpenMXPlayer.java
+++ b/OpenMXPlayer/src/net/pocketmagic/android/openmxplayer/OpenMXPlayer.java
@@ -211,6 +211,8 @@ public class OpenMXPlayer implements Runnable {
         int noOutputCounterLimit = 10;
         
         state.set(PlayerStates.PLAYING);
+        byte[] chunk = null;
+        int lastChunkSize = -1;
         while (!sawOutputEOS && noOutputCounter < noOutputCounterLimit && !stop) {
         	
         	// pause implementation
@@ -251,7 +253,11 @@ public class OpenMXPlayer implements Runnable {
                 int outputBufIndex = res;
                 ByteBuffer buf = codecOutputBuffers[outputBufIndex];
 
-                final byte[] chunk = new byte[info.size];
+                //final byte[] chunk = new byte[info.size];
+                if(info.size != lastChunkSize){
+                    lastChunkSize = info.size;
+                    chunk = new byte[info.size];
+                }
                 buf.get(chunk);
                 buf.clear();
                 if(chunk.length > 0){        	


### PR DESCRIPTION
I didn't understand why byte[] chunk is declared as final, I changed like this to avoid gc invocation, am I going to experience trouble? Anyway thanks for sharing this project, it is very helpful
